### PR TITLE
feat(node): `root` is not necessary

### DIFF
--- a/config/nginxnode/node.mazey.net.conf
+++ b/config/nginxnode/node.mazey.net.conf
@@ -2,8 +2,11 @@ upstream node-feperf-monitor-server {
     server 127.0.0.1:7415;
 }
 server {
+    listen 80;
+    index index.html index.htm;
+    client_max_body_size 200m;
     server_name node.feperf.com node.mazey.net mazey.cn;
-    root /web/feperf-server;
+    # root /web/feperf-server;
 
     location ^~ /feperf/ {
         proxy_set_header    X-Real-IP $remote_addr;
@@ -14,5 +17,11 @@ server {
         proxy_pass http://node-feperf-monitor-server;
     }
 
-    include /web/conf/includes/static.conf;
+    location ~ .*\.(png|jpeg|jpg|gif|ico|webp|mp3|mp4|webm|wma|bmp|swf|flv|wmv|avi|apk|m3u8|doc|docx|xls|xlsx|ppt|pptx|txt|pdf|zip|exe)$ {
+        expires 30d;
+    }
+
+    location ~ .*\.(html|css|js|json|htm|shtml|xml|ts)$ {
+        expires 24h;
+    }
 }


### PR DESCRIPTION
The root directive is not strictly necessary, but it is highly recommended to set it. If you don't set the root directive, nginx will use the system's default root directory, which may not be what you want.